### PR TITLE
putIpfsJson uses pin param and pins v1 cid

### DIFF
--- a/dist/src/ipfs-util.js
+++ b/dist/src/ipfs-util.js
@@ -109,18 +109,12 @@ function putIpfsJson(obj, pin) {
                 case 0:
                     str = JSON.stringify(obj);
                     debug("adding ".concat(str));
-                    return [4 /*yield*/, node.add(str)];
+                    return [4 /*yield*/, node.add(str, { cidVersion: 1, pin: pin })];
                 case 1:
                     cid = (_a.sent()).cid;
                     debug("added ".concat(str));
-                    if (!pin) return [3 /*break*/, 3];
-                    return [4 /*yield*/, pinIpfsCid(cid)];
-                case 2:
-                    _a.sent();
-                    _a.label = 3;
-                case 3:
                     debug("put ".concat(cid));
-                    return [2 /*return*/, cid.toV1().toString()];
+                    return [2 /*return*/, cid.toString()];
             }
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etherpacks/dpack",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "author": "nikolai mushegian <mail@nikolai.fyi>",
   "license": "GPL-3.0",
   "main": "./dist/index.js",

--- a/src/ipfs-util.ts
+++ b/src/ipfs-util.ts
@@ -25,13 +25,10 @@ Please repack the pack containing ${cid}
 export async function putIpfsJson (obj: any, pin: boolean = false): Promise<string> {
   const str = JSON.stringify(obj)
   debug(`adding ${str}`)
-  const { cid } = await node.add(str)
+  const { cid } = await node.add(str, {cidVersion:1, pin:pin})
   debug(`added ${str}`)
-  if (pin) {
-    await pinIpfsCid(cid)
-  }
   debug(`put ${cid}`)
-  return cid.toV1().toString()
+  return cid.toString()
 }
 
 export async function pinIpfsCid (cid: string): Promise<void> {


### PR DESCRIPTION
This makes a few functional changes. In add() pin defaults to true, so previously putIpfsJson was always pinning and ignored the pin param.

The CID was converted to V1 after pinning, so the V0 CID was being pinned. Now that V1 is used in add the V1 CID will be pinned if the pin param is true.

Using V1 directly will produce different CIDs because V0 always used dag-pb for the codec and that was kept in the converted value, but now the raw codec will be used when adding with V1.

Also the toV1 conversion can be skipped as version is passed in AddOptions now. 