### PR TITLE
'create weth pack' - check that entry does not already exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/mocha": "^9.1.0",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "ts-mocha": "^9.0.2",
     "ts-standard": "^11.0.0",
     "typescript": "^4.4.2"

--- a/src/ipfs-util.ts
+++ b/src/ipfs-util.ts
@@ -34,6 +34,12 @@ export async function putIpfsJson (obj: any, pin: boolean = false): Promise<stri
   return cid.toV1().toString()
 }
 
+export async function hashIpfsJson(obj: any): Promise<string> {
+  const str = JSON.stringify(obj)
+  const { cid } = await node.add(str, {onlyHash: true})
+  return cid.toV1().toString()
+}
+
 export async function pinIpfsCid (cid: string): Promise<void> {
   if (isV0CID(cid)) {
     console.log(`

--- a/src/ipfs-util.ts
+++ b/src/ipfs-util.ts
@@ -40,6 +40,20 @@ export async function hashIpfsJson(obj: any): Promise<string> {
   return cid.toV1().toString()
 }
 
+export async function rmIpfsJson(cid: string): Promise<void> {
+  if (isV0CID(cid)) {
+    console.log(`
+WARN: Detected a V0 CID string. This warning will become an error very soon.
+Please repack the pack containing ${cid}
+`)
+  }
+
+  for await (const r of node.pin.ls(cid)) {
+    await node.pin.rm(r.cid)
+  }
+  for await (const r of node.repo.gc()) {}
+}
+
 export async function pinIpfsCid (cid: string): Promise<void> {
   if (isV0CID(cid)) {
     console.log(`

--- a/test/dpack-test.ts
+++ b/test/dpack-test.ts
@@ -14,8 +14,8 @@ const want = chai.expect
 
 let artCid, packCid
 after(async () => {
-  await rmIpfsJson(artCid)
-  await rmIpfsJson(packCid)
+  if( artCid != undefined )  await rmIpfsJson(artCid)
+  if( packCid != undefined ) await rmIpfsJson(packCid)
 })
 
 describe('end to end simple example', ()=>{

--- a/test/dpack-test.ts
+++ b/test/dpack-test.ts
@@ -1,7 +1,7 @@
 import {builder, getIpfsJson, load} from "../index"
 import { Dapp } from '../src/dapp';
 import { PackBuilder } from '../src/builder';
-import {hashIpfsJson, putIpfsJson} from "../src/ipfs-util"
+import {hashIpfsJson, putIpfsJson, rmIpfsJson} from "../src/ipfs-util"
 import * as pure from '../src/pure'
 
 const debug = require('debug')('dpack:test')
@@ -12,9 +12,16 @@ const chai = require('chai')
 chai.use(require('chai-as-promised'))
 const want = chai.expect
 
+let artCid, packCid
+after(async () => {
+  await rmIpfsJson(artCid)
+  await rmIpfsJson(packCid)
+})
+
 describe('end to end simple example', ()=>{
   const packPath = path.join(__dirname, './data/weth_ropsten.dpack.json')
   let cidStr
+
 
   it('create weth pack', async () => {
     const contractAddress = '0xc778417E063141139Fce010982780140Aa0cD5Ab'
@@ -24,7 +31,7 @@ describe('end to end simple example', ()=>{
     // After compiling and deploying a contract we have the contract.address and json artifact containing the ABI and
     // bytecode. These are used to create a pack:
     debug('checking artifact not already added')
-    const artCid = await hashIpfsJson(artifact)
+    artCid = await hashIpfsJson(artifact)
     await want(getIpfsJson(artCid)).to.be.rejectedWith(Error)
     const pb = new builder('ropsten');
     await pb.packObject({
@@ -46,7 +53,7 @@ describe('end to end simple example', ()=>{
     // The pack can then be saved as a json file, or added to IPFS to be shared as a single CID for the whole protocol:
     fs.writeFileSync(packPath, JSON.stringify(pack, null, 2));
     debug('checking pack not already added')
-    const packCid = await hashIpfsJson(pack)
+    packCid = await hashIpfsJson(pack)
     await want(getIpfsJson(packCid)).to.be.rejectedWith(Error)
     cidStr = (await putIpfsJson(pack)).toString()
   })


### PR DESCRIPTION
The test shouldn't add data that already exists.  I'm trying to figure out how to cleanup the entry so that ipfs cat fails -- it seems it works even in offline mode after pin rm and repo gc.