### PR TITLE
fix(build): ensure es6loader is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@etherpacks/dpack",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "author": "nikolai mushegian <mail@nikolai.fyi>",
   "license": "GPL-3.0",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "tsc --build --clean && tsc",
+    "build": "tsc --build --clean && tsc && cp es6loader.js dist/",
     "test": "npm run build && ts-mocha test/*.ts --timeout=10000",
     "fmt": "ts-standard --fix src index.ts"
   },


### PR DESCRIPTION
## Fix: cp es6loader to dist/
es6loader can not be loaded as it is not in the `dist/` folder. 

### Example
```shell
$ npx hardhat
An unexpected error occurred:

Error: Cannot find module './es6loader'
```
### Fix
copy the es6loader file in the `build` step to the `dist` dir.
```json
    "build": "tsc --build --clean && tsc && cp es6loader.js dist/",
```


> Using dpack directly from github 
```json
    "@etherpacks/dpack": "https://github.com/dapphub/dpack"
``` 